### PR TITLE
chore: rename repo Dragonfly2 to dragonfly

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Join the conversation and help the community.
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
 - **Discussion Group**: <dragonfly-discuss@googlegroups.com>
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
-- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/Dragonfly2/discussions)
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
 
 ## Contributing
 
 You should check out our
-[CONTRIBUTING](https://github.com/dragonflyoss/Dragonfly2/blob/main/CONTRIBUTING.md) and develop the project together.
+[CONTRIBUTING](https://github.com/dragonflyoss/dragonfly/blob/main/CONTRIBUTING.md) and develop the project together.
 
 ## Code of Conduct
 
-Please refer to our [Code of Conduct](https://github.com/dragonflyoss/Dragonfly2/blob/main/CODE_OF_CONDUCT.md).
+Please refer to our [Code of Conduct](https://github.com/dragonflyoss/dragonfly/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request includes updates to the `README.md` file to correct URLs and references for the Dragonfly project. The most important changes are:

* Updated the GitHub Discussions link to point to the correct Dragonfly repository.
* Corrected the links for `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` to reflect the main repository.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/dragonflyoss/dragonfly/issues/3714
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
