### PR TITLE
chore: bump golang version to 1.23.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/perf-tests
 
-go 1.23.0
+go 1.23.8
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
This pull request includes a small change to the `go.mod` file. The change updates the Go version from 1.23.0 to 1.23.8.<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
