### PR TITLE
fix: remove shorthand for namespace

### DIFF
--- a/cmd/dfbench/cmd/dragonfly.go
+++ b/cmd/dfbench/cmd/dragonfly.go
@@ -51,7 +51,7 @@ var dragonflyCmd = &cobra.Command{
 func init() {
 	flags := dragonflyCmd.Flags()
 	flags.Uint32VarP(&cfg.Dragonfly.Number, "number", "n", cfg.Dragonfly.Number, "Specify the number of times to run the dragonfly benchmark")
-	flags.StringVarP(&cfg.Dragonfly.Namespace, "namespace", "s", cfg.Dragonfly.Namespace, "Specify the namespace to use for the dragonfly benchmark")
+	flags.StringVar(&cfg.Dragonfly.Namespace, "namespace", cfg.Dragonfly.Namespace, "Specify the namespace to use for the dragonfly benchmark")
 	flags.StringVarP(&cfg.Dragonfly.Downloader, "downloader", "d", cfg.Dragonfly.Downloader, "Specify the downloader to use for the dragonfly benchmark [dfget, proxy], default is dfget")
 	flags.StringVar(&cfg.Dragonfly.FileSizeLevel, "file-size-level", cfg.Dragonfly.FileSizeLevel, "Specify the file size level to use for the dragonfly benchmark [nano, micro, small, medium, large, xlarge, xxlarge], default is running all levels")
 

--- a/cmd/dfbench/cmd/nydus.go
+++ b/cmd/dfbench/cmd/nydus.go
@@ -47,7 +47,7 @@ var nydusCmd = &cobra.Command{
 func init() {
 	flags := nydusCmd.Flags()
 	flags.Uint32VarP(&cfg.Nydus.Number, "number", "n", cfg.Nydus.Number, "Specify the number of times to run the nydus benchmark")
-	flags.StringVarP(&cfg.Nydus.Namespace, "namespace", "s", cfg.Nydus.Namespace, "Specify the namespace to use for the nydus benchmark")
+	flags.StringVar(&cfg.Nydus.Namespace, "namespace", cfg.Nydus.Namespace, "Specify the namespace to use for the nydus benchmark")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache nydus flags to viper: %w", err))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request simplifies flag definitions in the `dfbench` CLI by removing shorthand options for the `--namespace` flag in both the `dragonfly` and `nydus` commands. This change improves consistency and reduces potential confusion caused by overlapping shorthand flags.

### Simplification of flag definitions:

* [`cmd/dfbench/cmd/dragonfly.go`](diffhunk://#diff-4557d97fc81241cd6ac1126180c253660329191588493e55ef8fc7de69c2cba0L54-R54): Removed the shorthand option `-s` for the `--namespace` flag in the `dragonfly` command, replacing `StringVarP` with `StringVar`.
* [`cmd/dfbench/cmd/nydus.go`](diffhunk://#diff-4364982a665a179bb57999c49370d6d6ef0aaa6013ebc3497ba6d0e43dbd50bbL50-R50): Removed the shorthand option `-s` for the `--namespace` flag in the `nydus` command, replacing `StringVarP` with `StringVar`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
