### PR TITLE
feat: add downloadURL parameter to downloadFileByDfget and downloadFileByProxy functions

### DIFF
--- a/pkg/dragonfly/dragonfly.go
+++ b/pkg/dragonfly/dragonfly.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"path"
 
 	"github.com/dragonflyoss/perf-tests/pkg/backend"
@@ -186,12 +187,18 @@ func (d *dragonfly) DownloadFileByDfget(ctx context.Context, fileSizeLevel backe
 		return err
 	}
 
+	downloadURL, err := d.fileServer.GetFileURL(fileSizeLevel, "dfget")
+	if err != nil {
+		logrus.Errorf("failed to get file URL: %v", err)
+		return err
+	}
+
 	var eg errgroup.Group
 	for _, pod := range pods {
 		podExec := util.NewPodExec(d.namespace, pod, "client")
 		eg.Go(func(podExec *util.PodExec) func() error {
 			return func() error {
-				if err := d.downloadFileByDfget(ctx, podExec, fileSizeLevel); err != nil {
+				if err := d.downloadFileByDfget(ctx, podExec, downloadURL, fileSizeLevel); err != nil {
 					return err
 				}
 				return nil
@@ -213,13 +220,7 @@ func (d *dragonfly) DownloadFileByDfget(ctx context.Context, fileSizeLevel backe
 }
 
 // downloadFileByDfget downloads file by dfget.
-func (d *dragonfly) downloadFileByDfget(ctx context.Context, podExec *util.PodExec, fileSizeLevel backend.FileSizeLevel) error {
-	downloadURL, err := d.fileServer.GetFileURL(fileSizeLevel, "dfget")
-	if err != nil {
-		logrus.Errorf("failed to get file URL: %v", err)
-		return err
-	}
-
+func (d *dragonfly) downloadFileByDfget(ctx context.Context, podExec *util.PodExec, downloadURL *url.URL, fileSizeLevel backend.FileSizeLevel) error {
 	outputPath, err := d.getOutput(fileSizeLevel, "dfget")
 	if err != nil {
 		logrus.Errorf("failed to get output path: %v", err)
@@ -248,12 +249,18 @@ func (d *dragonfly) DownloadFileByProxy(ctx context.Context, fileSizeLevel backe
 		return err
 	}
 
+	downloadURL, err := d.fileServer.GetFileURL(fileSizeLevel, "proxy")
+	if err != nil {
+		logrus.Errorf("failed to get file URL: %v", err)
+		return err
+	}
+
 	var eg errgroup.Group
 	for _, pod := range pods {
 		podExec := util.NewPodExec(d.namespace, pod, "client")
 		eg.Go(func(ctx context.Context, podExec *util.PodExec) func() error {
 			return func() error {
-				if err := d.downloadFileByProxy(ctx, podExec, fileSizeLevel); err != nil {
+				if err := d.downloadFileByProxy(ctx, podExec, downloadURL, fileSizeLevel); err != nil {
 					return err
 				}
 				return nil
@@ -275,13 +282,7 @@ func (d *dragonfly) DownloadFileByProxy(ctx context.Context, fileSizeLevel backe
 }
 
 // downloadFileByProxy downloads file by proxy.
-func (d *dragonfly) downloadFileByProxy(ctx context.Context, podExec *util.PodExec, fileSizeLevel backend.FileSizeLevel) error {
-	downloadURL, err := d.fileServer.GetFileURL(fileSizeLevel, "proxy")
-	if err != nil {
-		logrus.Errorf("failed to get file URL: %v", err)
-		return err
-	}
-
+func (d *dragonfly) downloadFileByProxy(ctx context.Context, podExec *util.PodExec, downloadURL *url.URL, fileSizeLevel backend.FileSizeLevel) error {
 	outputPath, err := d.getOutput(fileSizeLevel, "proxy")
 	if err != nil {
 		logrus.Errorf("failed to get output path: %v", err)


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request refactors the `DownloadFileByDfget` and `DownloadFileByProxy` methods in `pkg/dragonfly/dragonfly.go` to improve code clarity and reusability. The changes involve moving the file URL generation logic out of the helper methods and into the main methods, reducing redundancy.

### Refactoring of file download methods:

* **Centralized URL generation in `DownloadFileByDfget`**: Moved the `GetFileURL` call from the `downloadFileByDfget` helper method to the main `DownloadFileByDfget` method. The helper method now accepts the pre-generated `downloadURL` as a parameter. [[1]](diffhunk://#diff-df14229ea4b6a49906fbf13e87b0f23f865c8d66b07234dca8c2661debb907c8R190-R201) [[2]](diffhunk://#diff-df14229ea4b6a49906fbf13e87b0f23f865c8d66b07234dca8c2661debb907c8L216-R223)

* **Centralized URL generation in `DownloadFileByProxy`**: Similarly, moved the `GetFileURL` call from the `downloadFileByProxy` helper method to the main `DownloadFileByProxy` method. The helper method now accepts the pre-generated `downloadURL` as a parameter. [[1]](diffhunk://#diff-df14229ea4b6a49906fbf13e87b0f23f865c8d66b07234dca8c2661debb907c8R252-R263) [[2]](diffhunk://#diff-df14229ea4b6a49906fbf13e87b0f23f865c8d66b07234dca8c2661debb907c8L278-R285)

### Codebase improvements:

* **Added `net/url` import**: Introduced the `net/url` package to handle the `downloadURL` parameter type in the refactored methods.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
