### PR TITLE
chore(README.md): add maintainer google groups for communication channels and remove discussion group

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Running benchmark for all size levels by DFGET ...
 Join the conversation and help the community.
 
 - **Slack Channel**: [#dragonfly](https://cloud-native.slack.com/messages/dragonfly/) on [CNCF Slack](https://slack.cncf.io/)
-- **Discussion Group**: <dragonfly-discuss@googlegroups.com>
+- **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Developer Group**: <dragonfly-developers@googlegroups.com>
+- **Maintainer Group**: <dragonfly-maintainers@googlegroups.com>
 - **Github Discussions**: [Dragonfly Discussion Forum](https://github.com/dragonflyoss/dragonfly/discussions)
 - **Twitter**: [@dragonfly_oss](https://twitter.com/dragonfly_oss)
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the communication channels listed in the `README.md` file to reflect the current platforms used by the Dragonfly community.

### Updates to Communication Channels:
* Replaced the outdated "Discussion Group" email (`dragonfly-discuss@googlegroups.com`) with a link to the GitHub Discussions forum.
* Added a new "Maintainer Group" email (`dragonfly-maintainers@googlegroups.com`) to provide a direct contact point for maintainers.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
